### PR TITLE
update spindler service year

### DIFF
--- a/battery/spindler_battery.py
+++ b/battery/spindler_battery.py
@@ -7,6 +7,6 @@ class SpindlerBattery(Battery):
         self.__current_date = current_date
 
     def needs_service(self):
-        service_threshold_date = add_years_to_date(self.__last_service_date, 2)
+        service_threshold_date = add_years_to_date(self.__last_service_date, 3)
         return service_threshold_date < self.__current_date
     


### PR DESCRIPTION
### Modifications
- Spindler battery service year extended by 1 year

### Notes
-  Spindler battery requires service after three years instead of two